### PR TITLE
allow headless execution in entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,6 @@ RUN wget -q --show-progress --progress=bar:force:noscroll -P /opt/Sencha http://
 #RUN file_contents=$(</opt/Sencha/Cmd/7.0.0.40/sencha.vmoptions) \
 #    && echo "${file_contents//E/X}" > /opt/Sencha/Cmd/7.0.0.40/sencha.vmoptions
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This Docker image provides a build environment for Sencha ExtJS Apps. It is base
 * SenchaCmd Community Edition 7.0.0.40
 * Sencha ExtJS GNU GPLv3 versions 5.1.1, 6.2.0, and 7.0.0 in the directory `opt/Sencha`
 
+## Available tags
+
+The following stable dockerimage tags are available
+* v2.0.0 only support interactive execution of build
+* v2.1.0 now supports headless execution, e.g.,`docker run --rm -it -v $(pwd):/app --name sencha sencha-cmd:local command`
+
 ## Container Registry
 
 This image is being built automatically through GitHub Actions and published on [DockerHub](https://hub.docker.com/r/bwbohl/sencha-cmd) and the [GitHub Container Registry](https://github.com/bwbohl/sencha-cmd/pkgs/container/sencha-cmd) daily and on pushed tags with a semantic version number (cf. [https://semver.org](https://semver.org)). If a pull request is issued against the main branch of this repository, it will be built but not published.


### PR DESCRIPTION
Before these changes, running something like:

```bash
docker run --rm -it -v `pwd`:/app --name sencha sencha-cmd:local ./build.sh $OPTIONS
```
would result in a "Cannot execute binary file" error. This PR fixes that behaviour, making bash act as if it had been invoked as a login shell, and commands are read from the first non-option argument command_string.

Cf. https://stackoverflow.com/questions/61055324/docker-cannot-execute-binary-file